### PR TITLE
Add GetGp and GetMaxGp methods.

### DIFF
--- a/SomethingNeedDoing/Misc/CommandInterface.cs
+++ b/SomethingNeedDoing/Misc/CommandInterface.cs
@@ -152,6 +152,20 @@ public class CommandInterface : ICommandInterface
     }
 
     /// <inheritdoc/>
+    public int GetGp()
+    {
+        var gp = Service.ClientState.LocalPlayer?.CurrentGp ?? 0;
+        return (int)gp;
+    }
+
+    /// <inheritdoc/>
+    public int GetMaxGp()
+    {
+        var gp = Service.ClientState.LocalPlayer?.MaxGp ?? 0;
+        return (int)gp;
+    }
+
+    /// <inheritdoc/>
     public unsafe int GetStep()
     {
         var addon = this.GetSynthesisAddon();

--- a/SomethingNeedDoing/Misc/ICommandInterface.cs
+++ b/SomethingNeedDoing/Misc/ICommandInterface.cs
@@ -100,6 +100,18 @@ public interface ICommandInterface
     public int GetMaxCp();
 
     /// <summary>
+    /// Get the current GP amount.
+    /// </summary>
+    /// <returns>The current GP amount.</returns>
+    public int GetGp();
+
+    /// <summary>
+    /// Get the max GP amount.
+    /// </summary>
+    /// <returns>The max GP amount.</returns>
+    public int GetMaxGp();
+
+    /// <summary>
     /// Get the current step value.
     /// </summary>
     /// <returns>The current step value.</returns>


### PR DESCRIPTION
Was using a script from notnotmelon on the Punish discord, and it was using a hacky way of getting the GP from the collectable ui, which would error sometimes when it would fail to get the text from the window.  Adding functions to grab those values from Dalamud instead which should be more robust.