### PR TITLE
NeedsRepair(float below = 0)

### DIFF
--- a/SomethingNeedDoing/Interface/HelpWindow.cs
+++ b/SomethingNeedDoing/Interface/HelpWindow.cs
@@ -921,7 +921,7 @@ int GetMaxCp()
 
 int GetStep()
 int GetPercentHQ()
-bool NeedsRepair()
+bool NeedsRepair(float below = 0)
 
 // within: Return false if the next highest spiritbond is >= the within value.
 bool CanExtractMateria(float within = 100)


### PR DESCRIPTION
Changes `NeedsRepair()` to `NeedsRepair(float below = 0)` in the help window.