### PR TITLE
allow lua require() to require other macros

### DIFF
--- a/SomethingNeedDoing/Misc/ActiveMacro.cs
+++ b/SomethingNeedDoing/Misc/ActiveMacro.cs
@@ -257,6 +257,7 @@ internal partial class ActiveMacro : IDisposable
         RegisterClassMethods(this.lua, QuestCommands.Instance);
         RegisterClassMethods(this.lua, SystemCommands.Instance);
         RegisterClassMethods(this.lua, WorldStateCommands.Instance);
+        RegisterClassMethods(this.lua, InternalCommands.Instance);
         #endregion
 
         script = string.Format(EntrypointTemplate, script);
@@ -315,6 +316,8 @@ internal partial class ActiveMacro : IDisposable
 //        #endregion
 
         this.lua.DoString(FStringSnippet);
+        this.lua.DoString(PackageSearchersSnippet);
+
         var results = this.lua.DoString(script);
 
         if (results.Length == 0 || results[0] is not LuaFunction coro)
@@ -367,4 +370,10 @@ function f(str)
       end
    end))
 end";
+
+    private const string PackageSearchersSnippet = @"
+table.insert(package.searchers, 1, function(name)
+  return assert(load(InternalGetMacroText(name), name), ""`require` target not found: '"" .. name .. ""'"")
+end)
+";
 }

--- a/SomethingNeedDoing/Misc/Commands/InternalCommands.cs
+++ b/SomethingNeedDoing/Misc/Commands/InternalCommands.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Linq;
+
+namespace SomethingNeedDoing.Misc.Commands;
+
+public class InternalCommands
+{
+    internal static InternalCommands Instance { get; } = new();
+
+    public string InternalGetMacroText(string name)
+    {
+        return Service.Configuration
+            .GetAllNodes()
+            .OfType<MacroNode>()
+            .First(node => string.Equals(node.Name.Trim(), name.Trim(), StringComparison.InvariantCultureIgnoreCase))
+            .Contents
+            .Split(["\r\n", "\r", "\n"], StringSplitOptions.None)
+            .Select(line => $"  {line}")
+            .Join('\n');
+    }
+}


### PR DESCRIPTION
allows lua's `require` function to require other macros, e.g. by running `require("test")` it will find a macro named `test` and load that code. nested requires and so on all work as expected since it's all handled by lua, we just define a package searcher which uses a new internal command to fetch macro text and `load()` it on the lua side. if you have a few lua macros with common code it can be hard to keep them in sync, which this should help with.