### PR TITLE
improve require(), allow requiring files as well as macros

### DIFF
--- a/SomethingNeedDoing/Misc/ActiveMacro.cs
+++ b/SomethingNeedDoing/Misc/ActiveMacro.cs
@@ -391,15 +391,17 @@ table.insert(package.searchers, function(name) -- find files
 
   local abs_file = package.searchpath("""", name, '/') -- check absolute path
   if abs_file ~= nil then
-    return loadfile(abs_file, chunkname)
+    local loaded, err = loadfile(abs_file)
+    return assert(loaded, err), chunkname
   end
 
   for _, v in ipairs(snd.require.paths) do -- check in paths from snd.require.paths
     local path = v:gsub(""[/\\]*$"", """")
-    local file = package.searchpath("""", name, '/')
+    local rel_file = package.searchpath("""", name, '/')
         or package.searchpath(name, path .. ""\\?;"" .. path .. ""\\?.lua"", '/')
-    if file ~= nil then
-      return loadfile(file, chunkname)
+    if rel_file ~= nil then
+      local loaded, err = loadfile(rel_file)
+      return assert(loaded, err), chunkname
     end
   end
 
@@ -414,7 +416,8 @@ table.insert(package.searchers, function(name) -- find macros
   local chunkname = 'macro[""' .. macro .. '""]'
   local macro_text = InternalGetMacroText(macro)
   if macro_text ~= nil then
-    return load(macro_text, chunkname), chunkname
+    local loaded, err = load(macro_text)
+    return assert(loaded, err), chunkname
   end
   return 'no matching macro: ' .. chunkname
 end)

--- a/SomethingNeedDoing/Misc/ActiveMacro.cs
+++ b/SomethingNeedDoing/Misc/ActiveMacro.cs
@@ -372,8 +372,51 @@ function f(str)
 end";
 
     private const string PackageSearchersSnippet = @"
-table.insert(package.searchers, 1, function(name)
-  return assert(load(InternalGetMacroText(name), name), ""`require` target not found: '"" .. name .. ""'"")
+_G.snd = {
+  require = {
+    paths = {},
+    add_paths = function(...)
+      for k, v in pairs({ ... }) do
+        table.insert(snd.require.paths, v)
+      end
+    end
+  }
+}
+
+package.original_searchers = package.searchers
+package.searchers = { package.original_searchers[1] } -- keep the preload searcher
+table.insert(package.searchers, function(name) -- find files
+  if name:match("".macro$"") then return end
+  local chunkname = 'file[""' .. name .. '""]'
+
+  local abs_file = package.searchpath("""", name, '/') -- check absolute path
+  if abs_file ~= nil then
+    return loadfile(abs_file, chunkname)
+  end
+
+  for _, v in ipairs(snd.require.paths) do -- check in paths from snd.require.paths
+    local path = v:gsub(""[/\\]*$"", """")
+    local file = package.searchpath("""", name, '/')
+        or package.searchpath(name, path .. ""\\?;"" .. path .. ""\\?.lua"", '/')
+    if file ~= nil then
+      return loadfile(file, chunkname)
+    end
+  end
+
+  if #snd.require.paths > 0 then
+    return 'no matching file: ' .. chunkname .. ' in searched paths:\n  ' .. table.concat(snd.require.paths, '\n  ')
+  else
+    return 'no matching file: ' .. chunkname .. ' (and snd.require.paths was empty)'
+  end
+end)
+table.insert(package.searchers, function(name) -- find macros
+  local macro = string.gsub(name, "".macro$"", """")
+  local chunkname = 'macro[""' .. macro .. '""]'
+  local macro_text = InternalGetMacroText(macro)
+  if macro_text ~= nil then
+    return load(macro_text, chunkname), chunkname
+  end
+  return 'no matching macro: ' .. chunkname
 end)
 ";
 }

--- a/SomethingNeedDoing/Misc/Commands/InternalCommands.cs
+++ b/SomethingNeedDoing/Misc/Commands/InternalCommands.cs
@@ -7,12 +7,13 @@ public class InternalCommands
 {
     internal static InternalCommands Instance { get; } = new();
 
-    public string InternalGetMacroText(string name)
+    public string? InternalGetMacroText(string name)
     {
         return Service.Configuration
             .GetAllNodes()
             .OfType<MacroNode>()
-            .First(node => string.Equals(node.Name.Trim(), name.Trim(), StringComparison.InvariantCultureIgnoreCase))
+            .FirstOrDefault(node =>
+                string.Equals(node.Name.Trim(), name.Trim(), StringComparison.InvariantCultureIgnoreCase))?
             .Contents
             .Split(["\r\n", "\r", "\n"], StringSplitOptions.None)
             .Select(line => $"  {line}")


### PR DESCRIPTION
this improves further on the previous PR which added the ability to load macros with `require`. now `require` can load macros, files by absolute path, or files by relative path based on a list of search paths

the search order is:

1. files by absolute path, e.g. `require("C:\\Lua\\Script.lua")`
2. files by relative path, e.g. `require("script.lua")` or `require("test/script")` (the extension can be omitted in the case of relative paths). any path added to the `snd.require.paths` table (which is empty by default) will be searched. to make adding to this table easier, call the `snd.require.add_paths` function to add multiple paths at once, e.g. `snd.require.add_paths([[C:\Lua]], [[C:\Lua\Etc]])`.
3. macros, e.g. `require("mymacro")`.

other small small issues were also fixes and error messages were improved.