### PR TITLE
Add GetActiveMiniMapGatheringMarkers

### DIFF
--- a/SomethingNeedDoing/Misc/Commands/WorldStateCommands.cs
+++ b/SomethingNeedDoing/Misc/Commands/WorldStateCommands.cs
@@ -29,7 +29,7 @@ public class WorldStateCommands
         60465, // Fishing (gold)
         60466, // Unspoiled Fishing
         60929, // Fishing (alt, spearfishing?)
-        60930 // Unspoiled Fishing (alt, spearfishing?)
+        60930 // Unspoiled Fishing (Swimming Shadows)
     ];
 
     public List<string> ListAllFunctions()
@@ -176,6 +176,7 @@ public class WorldStateCommands
                     1 => "Legendary",
                     2 => "Unspoiled",
                     4 => "Ephemeral",
+                    5 => "Swimming Shadows",
                     _ => $"Unknown ({i})"
                 },
                 level: uint.Parse(Regex.Match(marker.TooltipText.ToString(), @"\d+").Value),


### PR DESCRIPTION
Returns a list (cannot use pairs) of SimpleGatheringMarker. Valid properties are `Tooltip`, `Type`, `Level`, `IconId`, and `Position`.

```lua
yield("/ac \"Shark Eye\"")
yield("/wait 0.5")
local nodeList = GetActiveMiniMapGatheringMarkers()
for i=0, nodeList.Count - 1 do
  yield("/echo " .. tostring(nodeList[i]))
end
```

`Lv. 65 Teeming Waters (Type = Survey, IconId = 60929, Level = 65, Position = <289.5625, -425.375>)`

If you have a method to convert it to a `table`, I'm all ears - NLua isn't super well documented. Also would like feedback if you want the properties and Type values capitalized or not.