### PR TITLE
Exposing more fate related values from FFXIVClientStructs

### DIFF
--- a/SomethingNeedDoing/Misc/Commands/WorldStateCommands.cs
+++ b/SomethingNeedDoing/Misc/Commands/WorldStateCommands.cs
@@ -61,12 +61,14 @@ public class WorldStateCommands
         .FirstOrDefault();
 
     public unsafe bool IsInFate() => FateManager.Instance()->CurrentFate is not null;
+    public unsafe int GetFateStartTimeEpoch(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->StartTimeEpoch;
     public unsafe float GetFateDuration(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->Duration;
     public unsafe float GetFateHandInCount(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->HandInCount;
     public unsafe float GetFateLocationX(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->Location.X;
     public unsafe float GetFateLocationY(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->Location.Y;
     public unsafe float GetFateLocationZ(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->Location.Z;
     public unsafe float GetFateProgress(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->Progress;
+    public unsafe bool GetFateIsBonus(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->IsBonus;
     #endregion
 
     public float DistanceBetween(float x1, float y1, float z1, float x2, float y2, float z2) => Vector3.DistanceSquared(new Vector3(x1, y1, z1), new Vector3(x2, y2, z2));

--- a/SomethingNeedDoing/Misc/Commands/WorldStateCommands.cs
+++ b/SomethingNeedDoing/Misc/Commands/WorldStateCommands.cs
@@ -69,6 +69,7 @@ public class WorldStateCommands
     public unsafe float GetFateLocationZ(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->Location.Z;
     public unsafe float GetFateProgress(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->Progress;
     public unsafe bool GetFateIsBonus(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->IsBonus;
+    public unsafe uint GetFateNpcObjectId(ushort fateID) => FateManager.Instance()->FateDirector->FateNpcObjectId;
     #endregion
 
     public float DistanceBetween(float x1, float y1, float z1, float x2, float y2, float z2) => Vector3.DistanceSquared(new Vector3(x1, y1, z1), new Vector3(x2, y2, z2));

--- a/SomethingNeedDoing/Misc/Commands/WorldStateCommands.cs
+++ b/SomethingNeedDoing/Misc/Commands/WorldStateCommands.cs
@@ -63,6 +63,7 @@ public class WorldStateCommands
     public unsafe bool IsInFate() => FateManager.Instance()->CurrentFate is not null;
     public unsafe int GetFateStartTimeEpoch(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->StartTimeEpoch;
     public unsafe float GetFateDuration(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->Duration;
+    public unsafe string GetFateName(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->Name.ToString();
     public unsafe float GetFateHandInCount(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->HandInCount;
     public unsafe float GetFateLocationX(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->Location.X;
     public unsafe float GetFateLocationY(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->Location.Y;


### PR DESCRIPTION
Exposing values from [FFXIVClientStructs/FateContext.cs](https://github.com/aers/FFXIVClientStructs/blob/ae606031531c22bf70336d776dc4df1e116ebcad/FFXIVClientStructs/FFXIV/Client/Game/Fate/FateContext.cs#L10) for:
- FateContext.StartTimeEpoch
- FateContext.IsBonus
- FateContext.Name

I believe `StartTimeEpoch` is the value I need to calculate how much time is left in each fate. Unfortunately, `Duration` doesn't seem to do this and instead only tracks how long the fate is supposed to last (900s or 15min for most regular fates).

`IsBonus` for determining which fates to prioritize.