### PR TITLE
exposing fate radius and removing npc id

### DIFF
--- a/SomethingNeedDoing/Misc/Commands/WorldStateCommands.cs
+++ b/SomethingNeedDoing/Misc/Commands/WorldStateCommands.cs
@@ -70,7 +70,7 @@ public class WorldStateCommands
     public unsafe float GetFateLocationZ(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->Location.Z;
     public unsafe float GetFateProgress(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->Progress;
     public unsafe bool GetFateIsBonus(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->IsBonus;
-    public unsafe uint GetFateNpcObjectId(ushort fateID) => FateManager.Instance()->FateDirector->FateNpcObjectId;
+    public unsafe float GetFateRadius(ushort fateID) => FateManager.Instance()->GetFateById(fateID)->Radius;
     #endregion
 
     public float DistanceBetween(float x1, float y1, float z1, float x2, float y2, float z2) => Vector3.Distance(new Vector3(x1, y1, z1), new Vector3(x2, y2, z2));


### PR DESCRIPTION
- exposed fate radius on behalf of scoob
- removed `GetFateNpcObjectId`, because i realized it doesn't actually use `fateID`. it just statically returns 3758096384 every time. i guess all fate npcs share the same id?