### PR TITLE
add GetItemName

### DIFF
--- a/SomethingNeedDoing/Macros/LuaFunctions/Inventory.cs
+++ b/SomethingNeedDoing/Macros/LuaFunctions/Inventory.cs
@@ -103,4 +103,6 @@ public class Inventory
 
 
     public List<uint> GetTradeableWhiteItemIDs() => Svc.Data.GetExcelSheet<Item>()!.Where(x => !x.IsUntradable && x.Rarity == (byte)ItemRarity.White).Select(x => x.RowId).ToList();
+
+    public string GetItemName(uint itemId) => Svc.Data.GetExcelSheet<Item>()!.GetRow(itemId).Name.ExtractText();
 }

--- a/SomethingNeedDoing/Misc/Changelog.cs
+++ b/SomethingNeedDoing/Misc/Changelog.cs
@@ -19,6 +19,10 @@ internal class Changelog
         using var font = ImRaii.PushFont(UiBuilder.MonoFont);
 
         DisplayChangelog(
+        "2025-02-22",
+        "- Added GetItemName()\n");
+
+        DisplayChangelog(
         "2025-02-17",
         "- Added IsLeveAccepted()\n");
 


### PR DESCRIPTION
looks up item name given id

([I actually tested it this time, I swear](https://i.imgur.com/XHXyKrL.png))

Could use `...Name.ToString()` as well - I didn't see any difference between them for this.