### PR TITLE
Update LegendaryFarmer-1.0.4.lua

### DIFF
--- a/Community Scripts/Gathering/LegendaryFarmer-1.0.4.lua
+++ b/Community Scripts/Gathering/LegendaryFarmer-1.0.4.lua
@@ -742,6 +742,7 @@ function RepairExtractReduceCheck()
             end
             Id_Print("Attempting to extract materia...")
             yield("/generalaction \"Materia Extraction\"")
+            yield("/wait " .. interval_rate * 30)
             yield("/waitaddon Materialize")
 
             while CanExtractMateria(100) == true do


### PR DESCRIPTION
Added Line 745  - yield("/wait " .. interval_rate * 30) Fixes "addon Materialize not found" error by giving the Materia Extraction window time to appear.