### PR TITLE
fix GetZoneName

### DIFF
--- a/SomethingNeedDoing/Macros/LuaFunctions/WorldState.cs
+++ b/SomethingNeedDoing/Macros/LuaFunctions/WorldState.cs
@@ -34,7 +34,7 @@ public class WorldState
     }
 
     public int GetZoneID() => Svc.ClientState.TerritoryType;
-    public string GetZoneName(uint zoneID) => GetRow<TerritoryType>(zoneID)!.Value.PlaceName.Value.ToString() ?? "";
+    public string GetZoneName(uint zoneID) => GetRow<TerritoryType>(zoneID)!.Value.PlaceName.Value.Name.ToString() ?? "";
     public unsafe float GetFlagXCoord() => AgentMap.Instance()->FlagMapMarker.XFloat;
     public unsafe float GetFlagYCoord() => AgentMap.Instance()->FlagMapMarker.YFloat;
     public unsafe float GetFlagZone() => AgentMap.Instance()->FlagMapMarker.TerritoryId;


### PR DESCRIPTION
Currently this just returns `Lumina.Excel.Sheets.PlaceName` instead of the actual name. This should fix it. https://i.imgur.com/Nj8b9vA.png