### PR TITLE
fix bug due to synchronization when calling character post process

### DIFF
--- a/SomethingNeedDoing/Config.cs
+++ b/SomethingNeedDoing/Config.cs
@@ -43,7 +43,18 @@ public class Config : IEzConfig
     public int BeepCount { get; set; } = 3;
     public bool UseSNDTargeting { get; set; } = true;
 
-    public MacroNode? ARCharacterPostProcessMacro { get; set; }
+    public MacroNode? ARCharacterPostProcessMacro
+    {
+        get;
+        set
+        {
+            if (value != null)
+            {
+                value.IsPostProcess = true;
+            }
+            field = value;
+        }
+    }
     public List<ulong> ARCharacterPostProcessExcludedCharacters { get; set; } = [];
 
     public bool StopMacroIfActionTimeout { get; set; } = true;

--- a/SomethingNeedDoing/ConfigTypes.cs
+++ b/SomethingNeedDoing/ConfigTypes.cs
@@ -29,6 +29,7 @@ public class MacroNode : INode
     /// Gets or sets a value indicating whether this macro should loop automatically.
     /// </summary>
     public bool CraftingLoop { get; set; } = false;
+    public bool IsPostProcess { get; set; } = false;
 
     /// <summary>
     /// Gets or sets a value indicating how many loops this macro should run if looping is enabled.

--- a/SomethingNeedDoing/Managers/MacroManager.cs
+++ b/SomethingNeedDoing/Managers/MacroManager.cs
@@ -60,7 +60,10 @@ internal partial class MacroManager : IDisposable
 
                 State = LoopState.Running;
                 if (await ProcessMacro(macro, token))
+                {
                     macroStack.Pop().Dispose();
+                    OnMacroCompleted?.Invoke(macro.Node);
+                }
             }
             catch (OperationCanceledException)
             {
@@ -178,6 +181,7 @@ internal partial class MacroManager : IDisposable
 
 internal sealed partial class MacroManager
 {
+    public event Action<MacroNode> OnMacroCompleted;
     public (string Name, int StepIndex)[] MacroStatus
         => macroStack
             .ToArray() // Collection was modified after the enumerator was instantiated.


### PR DESCRIPTION
**BUG description:** The current code uses polling to determine whether the character post processing is finished, which has a chance of missing the condition 
```C++
Service.MacroManager.State != LoopState.Running
```
I have encountered the situation that the CharacterPostProcess script didn't work many times, when I used script A to manage AutoRetainer, and AR called CharacterPostProcess script when script A is still running.